### PR TITLE
fix: Set correct base path in Vite config for GitHub Pages

### DIFF
--- a/tecnova/vite.config.js
+++ b/tecnova/vite.config.js
@@ -6,6 +6,7 @@ import autoprefixer from 'autoprefixer';
 // import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
+  base: '/news-nexus-interactive/', // Added for GitHub Pages deployment
   plugins: [
     // Optional: If Svelte is chosen, uncomment
     // svelte(),


### PR DESCRIPTION
Updates vite.config.js to include `base: '/news-nexus-interactive/'`. This ensures that asset paths are generated correctly when the project is deployed to a subdirectory, specifically for the GitHub Pages site at /news-nexus-interactive/. This change is crucial for resolving issues where the site appears as a blank white screen due to assets not being found.